### PR TITLE
don't use subpackages for computing longest common prefix

### DIFF
--- a/license-bill-of-materials.go
+++ b/license-bill-of-materials.go
@@ -651,7 +651,7 @@ func main() {
 		log.Fatal("expect at least one package argument")
 	}
 
-	overrides := ""
+	overrides := "[]"
 	if len(*of) != 0 {
 		b, err := ioutil.ReadFile(*of)
 		if err != nil {

--- a/license-bill-of-materials.go
+++ b/license-bill-of-materials.go
@@ -462,10 +462,12 @@ func longestCommonPrefix(licenses []License) string {
 	type Node struct {
 		Name     string
 		Children map[string]*Node
+		Shared   int
 	}
 	// Build a prefix tree. Not super efficient, but easy to do.
 	root := &Node{
 		Children: map[string]*Node{},
+		Shared:   len(licenses),
 	}
 	for _, l := range licenses {
 		n := root
@@ -478,6 +480,7 @@ func longestCommonPrefix(licenses []License) string {
 				}
 				n.Children[part] = c
 			}
+			c.Shared++
 			n = c
 		}
 	}
@@ -488,7 +491,12 @@ func longestCommonPrefix(licenses []License) string {
 			break
 		}
 		for _, c := range n.Children {
-			prefix = append(prefix, c.Name)
+			if c.Shared == len(licenses) {
+				// Handle case where there are subpackages:
+				// prometheus/procfs
+				// prometheus/procfs/xfs
+				prefix = append(prefix, c.Name)
+			}
 			n = c
 			break
 		}

--- a/license-bill-of-materials_test.go
+++ b/license-bill-of-materials_test.go
@@ -244,3 +244,41 @@ func TestOverrides(t *testing.T) {
 		}
 	}
 }
+
+func TestLongestPrefix(t *testing.T) {
+	tests := []struct {
+		lics []License
+
+		wpfx string
+	}{
+		{
+			[]License{
+				{Package: "a/b/c"},
+				{Package: "a/b/c/d"},
+			},
+			"a/b/c",
+		},
+		{
+			[]License{
+				{Package: "a/b/c"},
+				{Package: "a/b/c/d"},
+				{Package: "a/b/c/d/e"},
+			},
+			"a/b/c",
+		},
+		{
+			[]License{
+				{Package: "a/b"},
+				{Package: "a/b/c/d/f"},
+				{Package: "a/b/c/d/e"},
+			},
+			"a/b",
+		},
+	}
+
+	for i, tt := range tests {
+		if s := longestCommonPrefix(tt.lics); s != tt.wpfx {
+			t.Errorf("#%d: got %q, expected %q", i, s, tt.wpfx)
+		}
+	}
+}


### PR DESCRIPTION
If including two packages pkg/a and pkg/a/b with the license in pkg/a, the
old algorithm would treat pkg/a/b/ as a common prefix.