### PR TITLE
*: add override packages even if elided by top level license

### DIFF
--- a/license-bill-of-materials.go
+++ b/license-bill-of-materials.go
@@ -614,19 +614,21 @@ func pkgsToLicenses(pkgs []string, overrides string) (pls []projectAndLicense, n
 				License:    l,
 				Confidence: 1.0,
 			}
+			delete(fplm, pl.Project)
 		}
 		pls = append(pls, pl)
 	}
-
+	// force add undetected licenses given by overrides
+	for proj, l := range fplm {
+		pls = append(pls, projectAndLicense{
+			Project:    proj,
+			License:    l,
+			Confidence: 1.0,
+		})
+	}
 	// missing / error license
 	for _, pl := range e {
-		if l, ok := fplm[pl.Project]; ok {
-			pls = append(pls, projectAndLicense{
-				Project:    pl.Project,
-				License:    l,
-				Confidence: 1.0,
-			})
-		} else {
+		if _, ok := fplm[pl.Project]; !ok {
 			ne = append(ne, pl)
 		}
 	}


### PR DESCRIPTION
Internal packages are grouped with a top level license if there's no license
given in the package.