### PR TITLE
*: sort by Project before marshalling

### DIFF
--- a/license-bill-of-materials.go
+++ b/license-bill-of-materials.go
@@ -641,6 +641,8 @@ func pkgsToLicenses(pkgs []string, overrides string) (pls []projectAndLicense, n
 		}
 	}
 
+	sort.Slice(pls, func(i, j int) bool { return pls[i].Project < pls[j].Project })
+	sort.Slice(ne, func(i, j int) bool { return ne[i].Project < ne[j].Project })
 	return pls, ne
 }
 

--- a/license-bill-of-materials_test.go
+++ b/license-bill-of-materials_test.go
@@ -218,8 +218,8 @@ func TestStandardPackages(t *testing.T) {
 func TestOverrides(t *testing.T) {
 	wl := []projectAndLicense{
 		{Project: "colors/broken", License: "GNU General Public License v3.0", Confidence: 1},
-		{Project: "colors/red", License: "override existing", Confidence: 1},
 		{Project: "colors/missing", License: "override missing", Confidence: 1},
+		{Project: "colors/red", License: "override existing", Confidence: 1},
 	}
 	override := `[
 		{"project": "colors/missing", "license": "override missing"},


### PR DESCRIPTION
Having inconsistent outputs when I try updating `bill-of-materials.json` in etcd with MacOS.